### PR TITLE
SettingStates fix for Get_DeviceManagement_ManagedDevices_DeviceCompl…

### DIFF
--- a/PowerShellCmdlets/Generated/SDK/DeviceManagement/ManagedDevices/DeviceCompliancePolicyStates.cs
+++ b/PowerShellCmdlets/Generated/SDK/DeviceManagement/ManagedDevices/DeviceCompliancePolicyStates.cs
@@ -99,7 +99,8 @@ namespace Microsoft.Intune.PowerShellGraphSDK.PowerShellCmdlets
 
         internal override System.String GetResourcePath()
         {
-            return $"deviceManagement/managedDevices/{managedDeviceId}/deviceCompliancePolicyStates/{deviceCompliancePolicyStateId ?? string.Empty}";
+            /// Addition of /settingStates as used in Intune > Devices > {Device} > Device Complaince > {Policy}
+            return $"deviceManagement/managedDevices/{managedDeviceId}/deviceCompliancePolicyStates/{(deviceCompliancePolicyStateId==null?null: deviceCompliancePolicyStateId+ "/settingStates") ?? string.Empty}";
         }
     }
 

--- a/PowerShellCmdlets/Generated/SDK/DeviceManagement/ManagedDevices/DeviceConfigurationStates.cs
+++ b/PowerShellCmdlets/Generated/SDK/DeviceManagement/ManagedDevices/DeviceConfigurationStates.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Intune.PowerShellGraphSDK.PowerShellCmdlets
 
         internal override System.String GetResourcePath()
         {
-            return $"deviceManagement/managedDevices/{managedDeviceId}/deviceConfigurationStates/{deviceConfigurationStateId ?? string.Empty}";
+            return $"deviceManagement/managedDevices/{managedDeviceId}/deviceConfigurationStates/{(deviceConfigurationStateId == null ? null : deviceConfigurationStateId + "/settingStates") ?? string.Empty}";
         }
     }
 


### PR DESCRIPTION
Should fix the Get_DeviceManagement_ManagedDevices_DeviceCompliancePolicyStates cmdlet not returning anything when the deviceCompliancePolicyStateId is provided. Returns a value pair, so you need to do, for instance,  

```powershell
(get-devicemanagement_manageddevices_DeviceCompliancePolicyStates -managedDeviceId $DeviceGuid -deviceCompliancePolicyStateId $DeviceCompliancePolicyStateID).value
```